### PR TITLE
Update FXTL points address to final address

### DIFF
--- a/pages/fraxtal/fraxtal-incentives/fraxtal-point-system.mdx
+++ b/pages/fraxtal/fraxtal-incentives/fraxtal-point-system.mdx
@@ -15,6 +15,6 @@ The FXTL points smart contract is deployed and interactable on Fraxtal mainnet:
 
 |     **Contract**     	|                 **Address**                	|                                               **Chain explorer link**                                              	|
 |:-------------------:	|:------------------------------------------:	|:------------------------------------------------------------------------------------------------------------------:	|
-|    **FxtlPoints**     |  0x7f444B035E55C2956653f69F0366A7045a9bE846 	|     [FxtlPoints](https://fraxscan.com/address/0x7f444B035E55C2956653f69F0366A7045a9bE846#code)     	|
+|    **FxtlPoints**     |  0xab4b7c5c9a7c8ebb97877085a6c3550ad4ed3f97e 	|     [FxtlPoints](https://fraxscan.com/token/0xab4b7c5c9a7c8ebb97877085a6c3550ad4ed3f97e)     	|
 
-{/* FraxtalPoints: [FxtlPoints.sol](https://github.com/FraxFinance/dev-fraxchain-contracts/blob/add-flox-points/src/contracts/flox/FxtlPoints.sol) [0x7f444B035E55C2956653f69F0366A7045a9bE846] */}
+{/* FraxtalPoints: [FxtlPoints.sol](https://github.com/FraxFinance/dev-fraxchain-contracts/blob/add-flox-points/src/contracts/flox/FxtlPoints.sol) [0xab4b7c5c9a7c8ebb97877085a6c3550ad4ed3f97e] */}


### PR DESCRIPTION
The final version of FXTL points has been deployed to the mainnet. This commit updates the address of the smart contract to the final address that will be used for all FTXL points.