### PR TITLE
small copy fix in description

### DIFF
--- a/public/ecosystem-data.json
+++ b/public/ecosystem-data.json
@@ -449,7 +449,7 @@
       "key": "snailminting",
       "name": "Snailminting",
       "url": "https://snailmint.ing",
-      "description": "Minting snails everyday until FXS is $100",
+      "description": "Minting snails everyday until FXS is at $100",
       "tags": ["NFT"],
       "imageUrl": "https://snailmint.ing/fxs_snail_2.png"
     }


### PR DESCRIPTION
Small copywriting change. Should be "Minting snails every day until FXS is at $100" instead of "Minting snails every day until FXS is $100"