### PR TITLE
Add Flox quests

### DIFF
--- a/pages/fraxtal/fraxtal-incentives/_meta.json
+++ b/pages/fraxtal/fraxtal-incentives/_meta.json
@@ -1,5 +1,6 @@
 {
   "fraxtal-point-system": "Fraxtal point system (FXTL)",
   "fraxtal-blockspace-incentives": "Fraxtal blockspace incentives (Flox)",
-  "fraxtal-incentives-delegation": "Fraxtal incentives delegation"
+  "fraxtal-incentives-delegation": "Fraxtal incentives delegation",
+  "flox-quests": "Flox quests"
 }

--- a/pages/fraxtal/fraxtal-incentives/flox-quests.mxd
+++ b/pages/fraxtal/fraxtal-incentives/flox-quests.mxd
@@ -1,0 +1,12 @@
+---
+title: Flox Quest System
+lang: en-US
+---
+
+# Flox Quest System
+
+The Flox Quest System allows you to earn FXTL points by completing a set of objectives.
+
+We parthered with Layer3 to provide the FXTL bearing quests that can be found [here](https://app.layer3.xyz/category/fraxtal?slug=fraxtal).
+
+Remember to complete all of the stages of the quest and you will receive your FXTL points in within a week of completing it.


### PR DESCRIPTION
The Flox Quests page explains what the Flox Quest system is and where it can be accessed. It also provides a link to the Layer3 website where the quests can be found.