### PR TITLE
docs: Fix subject-verb agreement Update other-tokens.mdx

### DIFF
--- a/pages/fraxtal/addresses/other-tokens.mdx
+++ b/pages/fraxtal/addresses/other-tokens.mdx
@@ -6,4 +6,4 @@ lang: en-US
 ## Superchain Token List
 
 Various ERC-20 tokens originally deployed to Ethereum also have corresponding "bridged" representations on Fraxtal.
-The [Superchain Token List](https://github.com/ethereum-optimism/ethereum-optimism.github.io) exists to help users discover the correct bridged token addresses for each token.
+The [Superchain Token List](https://github.com/ethereum-optimism/ethereum-optimism.github.io) exist to help users discover the correct bridged token addresses for each token.


### PR DESCRIPTION
I noticed a grammatical error in the description where "exists" was used instead of "**exist**."
Since "Superchain Token List" is singular, the verb should agree with it.