### PR TITLE
Update FraxSwap Router Address 

### DIFF
--- a/pages/protocol/subprotocols/fraxswap/addresses.mdx
+++ b/pages/protocol/subprotocols/fraxswap/addresses.mdx
@@ -17,7 +17,7 @@ import * as mainnet from '~/misc/constants/mainnet';
 | Ethereum         | Router(Regular) | ```0xC14d550632db8592D1243Edc8B95b0Ad06703867```  |
 | Ethereum         | Router(Multihop)| ```0x25e9acA5951262241290841b6f863d59D37DC4f0```  |
 | Fraxtal          | Factory         | ```0xE30521fe7f3bEB6Ad556887b50739d6C7CA667E6```  |
-| Fraxtal          | Router(Regular) | ```0x000000004d232C91738A0458aD6C46ef191C131F```  |
+| Fraxtal          | Router(Regular) | ```0x7ae2A0f3D9eF911A0a3f726FA9fbFCA25Dc18f7A```  |
 | Fraxtal          | Router(Multihop)| ```0x00000000d3FA2B7Cd549d9A1755104E54E1CF41c```  |
 | Arbitrum         | Factory         | ```0x8374A74A728f06bEa6B7259C68AA7BBB732bfeaD```  |
 | Arbitrum         | Router          | ```0xCAAaB0A72f781B92bA63Af27477aA46aB8F653E7```  |


### PR DESCRIPTION
Add the most up to date addresses given the migration to the FRAX gas token on fraxtal