### PR TITLE
Fix typo in fiat onramp/offramp fee display

### DIFF
--- a/pages/frxusd/fiat-onramp-offramp.mdx
+++ b/pages/frxusd/fiat-onramp-offramp.mdx
@@ -117,7 +117,7 @@ Once connected, the system automatically creates two liquidation addresses for y
 ## Fees
 
 - **Exchange Fee**: May be applied by Bridge.xyz during currency conversion
-- **RWA Liquidation Fee**: A 0.01 BPS conversion fee may apply if real-world assets (RWAs) are being liquidated to meet cash redemptions
+- **RWA Liquidation Fee**: A 1 BPS conversion fee may apply if real-world assets (RWAs) are being liquidated to meet cash redemptions
 
 ## Security & Compliance
 


### PR DESCRIPTION
Fixed typo in RWA Liquidation Fee: corrected from 0.01 BPS to 1 BPS (0.01% = 1 BPS).