### PR TITLE
Add Envio to Indexers

### DIFF
--- a/pages/fraxtal/tools/indexers.mdx
+++ b/pages/fraxtal/tools/indexers.mdx
@@ -6,7 +6,7 @@ lang: en-US
 # Indexers
 ## Envio
 
-[Envio](https://envio.dev/?utm_source=fraxtal&utm_medium=partner-docs) is a high-performance indexing framework that turns Fraxtal smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Fraxtal, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC.
+[Envio](https://envio.dev/?utm_source=fraxtal&utm_medium=partner-docs) is the data layer for blockchain apps. It gives Fraxtal developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. On Fraxtal, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC.
 
 <details>
 <summary> Quick Start </summary>

--- a/pages/fraxtal/tools/indexers.mdx
+++ b/pages/fraxtal/tools/indexers.mdx
@@ -4,6 +4,28 @@ lang: en-US
 ---
 
 # Indexers
+## Envio
+
+[Envio](https://envio.dev/?utm_source=fraxtal&utm_medium=partner-docs) is a high-performance indexing framework that turns Fraxtal smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Fraxtal, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC.
+
+<details>
+<summary> Quick Start </summary>
+### Getting started
+*You can find the full documentation [here](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=fraxtal&utm_medium=partner-docs).*
+
+1. Auto-generate an indexer from any verified contract:
+
+```bash
+$ pnpx envio init
+```
+
+2. Write your event handlers in TypeScript, JavaScript, or ReScript, covering real-time and historical data with reorg support.
+
+3. Deploy to [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=fraxtal&utm_medium=partner-docs) for fully managed hosting, or self-host.
+
+Fraxtal is available on HyperSync at `https://fraxtal.hypersync.xyz`. Follow the [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=fraxtal&utm_medium=partner-docs) to get running, and see the [supported networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=fraxtal&utm_medium=partner-docs) list for details.
+</details>
+
 ## Goldsky
 [Goldsky](https://goldsky.com/) is a high-performance data indexing provider for Fraxtal that makes it easy to extract, transform, and load on-chain data to power both application and analytics use cases.
 

--- a/pages/fraxtal/tools/indexers.mdx
+++ b/pages/fraxtal/tools/indexers.mdx
@@ -24,6 +24,8 @@ $ pnpx envio init
 3. Deploy to [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=fraxtal&utm_medium=partner-docs) for fully managed hosting, or self-host.
 
 Fraxtal is available on HyperSync at `https://fraxtal.hypersync.xyz`. Follow the [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=fraxtal&utm_medium=partner-docs) to get running, and see the [supported networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=fraxtal&utm_medium=partner-docs) list for details.
+
+See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=fraxtal&utm_medium=partner-docs).
 </details>
 
 ## Goldsky


### PR DESCRIPTION
Adds Envio to the Indexers page for Fraxtal, matching the existing entry format.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Fraxtal it is powered by HyperSync for fast historical syncs.

- Website: https://envio.dev/
- Docs: https://docs.envio.dev/
- HyperIndex overview: https://docs.envio.dev/docs/HyperIndex/overview