### PR TITLE
Add SwiftNodes to the ecosystem directory (Infra)

### DIFF
--- a/public/ecosystem-data.json
+++ b/public/ecosystem-data.json
@@ -1,6 +1,16 @@
 {
   "items": [
     {
+      "key": "swiftnodes",
+      "name": "SwiftNodes",
+      "url": "https://swiftnodes.io/fraxtal-rpc",
+      "description": "SwiftNodes provides flat-rate RPC endpoints for Fraxtal over HTTP and WebSocket - one API key across 75+ networks, a free tier, and archive access on paid plans. No compute-unit metering.",
+      "tags": [
+        "Infra"
+      ],
+      "imageUrl": "https://swiftnodes.io/android-chrome-512x512.png"
+    },
+    {
       "key": "the-graph",
       "name": "The Graph",
       "url": "https://thegraph.com/docs/en/subgraphs/quick-start/",

--- a/public/ecosystem-data.json
+++ b/public/ecosystem-data.json
@@ -8,7 +8,7 @@
       "tags": [
         "Infra"
       ],
-      "imageUrl": "https://swiftnodes.io/android-chrome-512x512.png"
+      "imageUrl": "https://swiftnodes.io/icon-512.png"
     },
     {
       "key": "the-graph",


### PR DESCRIPTION
Adds SwiftNodes under the Infra tag, following the documented self-serve process in pages/fraxtal/contribute/ecosystem.mdx. SwiftNodes serves Fraxtal mainnet (chain ID 252) over HTTP and WebSocket with a free tier. Used an externally hosted imageUrl like several existing entries; happy to commit a PNG to public/images/ecosystem instead if preferred.